### PR TITLE
Add getting author sorted post count on hashtag

### DIFF
--- a/app/api/tag_search.py
+++ b/app/api/tag_search.py
@@ -13,7 +13,7 @@ import requests
 authtokens = tuple()
 
 instagram_root = "https://www.instagram.com"
-post_set={}
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -78,8 +78,8 @@ def get_query_id(doc):
                     query_ids.append(query_id)
     return query_ids
 
-def extract_recent_tag(tag):
-
+def get_post(tag):
+    post_set={}
     url_string = "https://www.instagram.com/explore/tags/%s/" % tag
     response = bs4.BeautifulSoup(requests.get(url_string).text, "html.parser")
     potential_query_ids = get_query_id(response)
@@ -131,16 +131,18 @@ def extract_recent_tag(tag):
             post_set[owner_id].append(node['node'])
         cnt+=1
         print(cnt)
+        
+    return post_set
 
 
-if __name__ == '__main__':
-    extract_recent_tag("구파발맛집")
-    ordering_sequence=[]
-    for key in post_set:
-        ordering_sequence.append((key,len(post_set[key]), useridToUsername(key)))
-    ordering_sequence.sort(key = lambda element : element[1], reverse=True)
+# if __name__ == '__main__':
+#     extract_recent_tag("구파발맛집")
+#     ordering_sequence=[]
+#     for key in post_set:
+#         ordering_sequence.append((key,len(post_set[key]), useridToUsername(key)))
+#     ordering_sequence.sort(key = lambda element : element[1], reverse=True)
     
-    with open(os.path.join(BASE_DIR, 'result.json'), 'w+', encoding='utf8') as f:
-        res=sorted(post_set.items(), key=lambda element : len(element[1]), reverse=True)
-        f.write(str(res))
+#     with open(os.path.join(BASE_DIR, 'result.json'), 'w+', encoding='utf8') as f:
+#         res=sorted(post_set.items(), key=lambda element : len(element[1]), reverse=True)
+#         f.write(str(res))
 

--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
 
-from .views import reply, dataParsing
+from .views import reply, dataParsing, get_place_based_hashtag
 
 urlpatterns = [
     path('reply', reply),
     path('parsing', dataParsing),
+    path('hashtag', get_place_based_hashtag),
 ]

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,23 +1,17 @@
 import pytest
 from app.models import *
 from app.api.views import *
-
-# @pytest.mark.django_db
-# def test_create_store():
-#     Store.objects.create(name="동화가든", shortcode='B50FQs0HTJI')
-#     store= Store.objects.get(name="동화가든")
-#     assert store.name=='동화가든'
-
-# @pytest.mark.django_db
-# def test_store():
-#     store = Store.objects.create(name="동화가든", shortcode='B50FQs0HTJI')
-#     assert store.name=='동화가든'
-
     
 @pytest.mark.django_db  
 def test_parsing():
     update_data()
     store = Store.objects.get(name="동화가든")
     assert store.shortcode=='B50FQs0HTJI'
+    
+def test_hashtag_search():
+    posts_set=get_post("구파발맛집")
+    result=hash_search(posts_set)
+    assert result['template']['outputs'][0]['carousel']['items'][0]['title']=='hello_saige'
+    
     
     


### PR DESCRIPTION
Fixes #10

Changes proposed in this pull request: 
* 사용자가 해시태그로 '#구파발맛집'을 검색했을 때 한 작성자에게는 하나의 게시물만 부여
* 브런치 관리/구분해주었음
* 추후 더 생각해봐야 할 것들은 다른 이슈로 파겠음
